### PR TITLE
Make Foreman exit with code from underlying tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Foreman Changelog
 
+## Unreleased
+- Fixed Foreman not propagating error codes from underlying tools. ([#20](https://github.com/rojo-rbx/foreman/pull/20))
+
 ## 1.0.1
 - Metadata fix for crates.io release
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod github;
 mod paths;
 mod tool_cache;
 
-use std::{env, error::Error, io};
+use std::{env, error::Error, io, process};
 
 use structopt::StructOpt;
 
@@ -58,7 +58,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                 ToolCache::download_if_necessary(&tool_spec.source, &tool_spec.version);
 
             if let Some(version) = maybe_version {
-                ToolCache::run(&tool_spec.source, &version, invocation.args);
+                let exit_code = ToolCache::run(&tool_spec.source, &version, invocation.args);
+
+                if exit_code != 0 {
+                    process::exit(exit_code);
+                }
             }
 
             return Ok(());

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -30,6 +30,7 @@ pub struct ToolCache {
 }
 
 impl ToolCache {
+    #[must_use]
     pub fn run(source: &str, version: &Version, args: Vec<String>) -> i32 {
         log::debug!("Running tool {}@{}", source, version);
 


### PR DESCRIPTION
Foreman was not correctly propagating error codes when it ran an underlying tool. This wasted a bit of time elsewhere, and we didn't think to blame Foreman! 😅 

I updated the signature of `ToolCache::run` to hopefully prevent this exact issue from popping up in the future. Had we annotated this function before, this bug would not have happened.