### PR TITLE
Refactor error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+- Improve error handling to reduces crashes and add more useful error messages ([#40](https://github.com/Roblox/foreman/pull/40))
 - Add environment variable to override Foreman home directory ([#39](https://github.com/Roblox/foreman/pull/39))
 - Support tools hosted on GitLab ([#31](https://github.com/Roblox/foreman/pull/31))
   - Updated config format to support both GitHub and GitLab tools

--- a/src/aliaser.rs
+++ b/src/aliaser.rs
@@ -3,12 +3,17 @@ use std::{
     path::Path,
 };
 
-use crate::fs;
+use crate::{
+    error::{ForemanError, ForemanResult},
+    fs,
+};
 
-pub fn add_self_alias(name: &str, bin_path: &Path) {
-    let foreman_path = env::current_exe().unwrap();
+pub fn add_self_alias(name: &str, bin_path: &Path) -> ForemanResult<()> {
+    let foreman_path = env::current_exe().map_err(|err| {
+        ForemanError::io_error_with_context(err, "unable to obtain foreman executable location")
+    })?;
     let mut alias_path = bin_path.to_owned();
     alias_path.push(format!("{}{}", name, EXE_SUFFIX));
 
-    fs::copy(foreman_path, alias_path).unwrap();
+    fs::copy(foreman_path, alias_path).map(|_| ())
 }

--- a/src/auth_store.rs
+++ b/src/auth_store.rs
@@ -1,9 +1,12 @@
-use std::{io, path::Path};
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use toml_edit::{value, Document};
+use toml_edit::{value, Document, TomlError};
 
-use crate::fs;
+use crate::{
+    error::{ForemanError, ForemanResult},
+    fs,
+};
 
 pub static DEFAULT_AUTH_CONFIG: &str = include_str!("../resources/default-auth.toml");
 
@@ -15,59 +18,47 @@ pub struct AuthStore {
 }
 
 impl AuthStore {
-    pub fn load(path: &Path) -> io::Result<Self> {
-        log::debug!("Loading auth store...");
+    pub fn load(path: &Path) -> ForemanResult<Self> {
+        if let Some(contents) = fs::try_read(path)? {
+            log::debug!("Loading auth store");
+            let store: AuthStore = toml::from_slice(&contents)
+                .map_err(|error| ForemanError::auth_parsing(path, error.to_string()))?;
 
-        match fs::read(path) {
-            Ok(contents) => {
-                let store: AuthStore = toml::from_slice(&contents).unwrap();
-
-                let mut found_credentials = false;
-                if store.github.is_some() {
-                    log::debug!("Found GitHub credentials");
-                    found_credentials = true;
-                }
-                if store.gitlab.is_some() {
-                    log::debug!("Found GitLab credentials");
-                    found_credentials = true;
-                }
-                if !found_credentials {
-                    log::debug!("Found no credentials");
-                }
-
-                Ok(store)
+            let mut found_credentials = false;
+            if store.github.is_some() {
+                log::debug!("Found GitHub credentials");
+                found_credentials = true;
             }
-            Err(err) => {
-                if err.kind() == io::ErrorKind::NotFound {
-                    Ok(AuthStore::default())
-                } else {
-                    Err(err)
-                }
+            if store.gitlab.is_some() {
+                log::debug!("Found GitLab credentials");
+                found_credentials = true;
             }
+            if !found_credentials {
+                log::debug!("Found no credentials");
+            }
+
+            Ok(store)
+        } else {
+            log::debug!("Auth store not found");
+            Ok(AuthStore::default())
         }
     }
 
-    pub fn set_github_token(auth_file: &Path, token: &str) -> io::Result<()> {
+    pub fn set_github_token(auth_file: &Path, token: &str) -> ForemanResult<()> {
         Self::set_token(auth_file, "github", token)
     }
 
-    pub fn set_gitlab_token(auth_file: &Path, token: &str) -> io::Result<()> {
+    pub fn set_gitlab_token(auth_file: &Path, token: &str) -> ForemanResult<()> {
         Self::set_token(auth_file, "gitlab", token)
     }
 
-    fn set_token(auth_file: &Path, key: &str, token: &str) -> io::Result<()> {
-        let contents = match fs::read_to_string(auth_file) {
-            Ok(contents) => contents,
-            Err(err) => {
-                if err.kind() == io::ErrorKind::NotFound {
-                    DEFAULT_AUTH_CONFIG.to_owned()
-                } else {
-                    return Err(err);
-                }
-            }
-        };
+    fn set_token(auth_file: &Path, key: &str, token: &str) -> ForemanResult<()> {
+        let contents =
+            fs::try_read_to_string(auth_file)?.unwrap_or_else(|| DEFAULT_AUTH_CONFIG.to_owned());
 
-        let mut store: Document = contents.parse().unwrap();
+        let mut store: Document = contents
+            .parse()
+            .map_err(|err: TomlError| ForemanError::auth_parsing(auth_file, err.to_string()))?;
         store[key] = value(token);
 
         let serialized = store.to_string();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,318 @@
+use std::{fmt, io, path::PathBuf};
+
+use semver::Version;
+
+use crate::config::ToolSpec;
+
+pub type ForemanResult<T> = Result<T, ForemanError>;
+
+#[derive(Debug)]
+pub enum ForemanError {
+    IO {
+        source: io::Error,
+        message: Option<String>,
+    },
+    Read {
+        source: io::Error,
+        path: PathBuf,
+    },
+    CreateFile {
+        source: io::Error,
+        path: PathBuf,
+    },
+    Write {
+        source: io::Error,
+        path: PathBuf,
+    },
+    Copy {
+        source: io::Error,
+        source_path: PathBuf,
+        destination_path: PathBuf,
+    },
+    #[cfg(unix)]
+    SetPermissions {
+        source: io::Error,
+        path: PathBuf,
+    },
+    ConfigFileParse {
+        source: String,
+        path: PathBuf,
+    },
+    AuthFileParse {
+        source: String,
+        path: PathBuf,
+    },
+    ToolCacheParse {
+        source: String,
+        path: PathBuf,
+    },
+    RequestFailed {
+        source: reqwest::Error,
+    },
+    UnexpectedResponseBody {
+        source: String,
+        response_body: String,
+        url: String,
+    },
+    NoCompatibleVersionFound {
+        tool: ToolSpec,
+        available_versions: Vec<Version>,
+    },
+    InvalidReleaseAsset {
+        tool: ToolSpec,
+        version: Version,
+        message: String,
+    },
+}
+
+impl ForemanError {
+    pub fn io_error_with_context<S: Into<String>>(source: io::Error, message: S) -> Self {
+        Self::IO {
+            source,
+            message: Some(message.into()),
+        }
+    }
+
+    pub fn read_error<P: Into<PathBuf>>(source: io::Error, path: P) -> Self {
+        Self::Read {
+            source,
+            path: path.into(),
+        }
+    }
+
+    pub fn create_file_error<P: Into<PathBuf>>(source: io::Error, path: P) -> Self {
+        Self::CreateFile {
+            source,
+            path: path.into(),
+        }
+    }
+
+    pub fn write_error<P: Into<PathBuf>>(source: io::Error, path: P) -> Self {
+        Self::Write {
+            source,
+            path: path.into(),
+        }
+    }
+
+    pub fn copy_error<P: Into<PathBuf>, P2: Into<PathBuf>>(
+        source: io::Error,
+        source_path: P,
+        destination_path: P2,
+    ) -> Self {
+        Self::Copy {
+            source,
+            source_path: source_path.into(),
+            destination_path: destination_path.into(),
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn set_permission_error<P: Into<PathBuf>>(source: io::Error, path: P) -> Self {
+        Self::SetPermissions {
+            source,
+            path: path.into(),
+        }
+    }
+
+    pub fn config_parsing<P: Into<PathBuf>, S: Into<String>>(config_path: P, source: S) -> Self {
+        Self::ConfigFileParse {
+            source: source.into(),
+            path: config_path.into(),
+        }
+    }
+
+    pub fn auth_parsing<P: Into<PathBuf>, S: Into<String>>(auth_path: P, source: S) -> Self {
+        Self::AuthFileParse {
+            source: source.into(),
+            path: auth_path.into(),
+        }
+    }
+
+    pub fn tool_cache_parsing<P: Into<PathBuf>, S: Into<String>>(path: P, source: S) -> Self {
+        Self::ToolCacheParse {
+            source: source.into(),
+            path: path.into(),
+        }
+    }
+
+    pub fn request_failed(source: reqwest::Error) -> Self {
+        Self::RequestFailed { source }
+    }
+
+    pub fn unexpected_response_body<S: Into<String>, S2: Into<String>, S3: Into<String>>(
+        source: S,
+        response_body: S2,
+        url: S3,
+    ) -> Self {
+        Self::UnexpectedResponseBody {
+            source: source.into(),
+            response_body: response_body.into(),
+            url: url.into(),
+        }
+    }
+
+    pub fn no_compatible_version_found(tool: &ToolSpec, available_versions: Vec<Version>) -> Self {
+        Self::NoCompatibleVersionFound {
+            tool: tool.clone(),
+            available_versions,
+        }
+    }
+
+    pub fn invalid_release_asset<S: Into<String>>(
+        tool: &ToolSpec,
+        version: &Version,
+        message: S,
+    ) -> Self {
+        Self::InvalidReleaseAsset {
+            tool: tool.clone(),
+            version: version.clone(),
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ForemanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IO { source, message } => {
+                if let Some(message) = message {
+                    write!(f, "{}: {}", message, source)
+                } else {
+                    write!(f, "io error: {}", source)
+                }
+            }
+            Self::Read { source, path } => write!(
+                f,
+                "an error happened trying to read {}: {}",
+                path.display(),
+                source
+            ),
+            Self::CreateFile { source, path } => write!(
+                f,
+                "an error happened trying to create file {}: {}",
+                path.display(),
+                source
+            ),
+            Self::Write { source, path } => write!(
+                f,
+                "an error happened trying to write {}: {}",
+                path.display(),
+                source
+            ),
+            Self::Copy {
+                source,
+                source_path,
+                destination_path,
+            } => write!(
+                f,
+                "an error happened copying {} to {}: {}",
+                source_path.display(),
+                destination_path.display(),
+                source
+            ),
+            #[cfg(unix)]
+            Self::SetPermissions { source, path } => write!(
+                f,
+                "an error happened trying to set permissions on {}: {}",
+                path.display(),
+                source
+            ),
+            Self::ConfigFileParse { source, path } => write!(
+                f,
+                "unable to parse Foreman configuration file (at {}): {}\n\n{}",
+                path.display(),
+                source,
+                FOREMAN_CONFIG_HELP
+            ),
+            Self::AuthFileParse { source, path } => write!(
+                f,
+                "unable to parse Foreman authentication file (at {}): {}\n\n{}",
+                path.display(),
+                source,
+                FOREMAN_AUTH_HELP
+            ),
+            Self::ToolCacheParse { source, path } => {
+                write!(
+                    f,
+                    "unable to parse Foreman tool cache file (at {}): {}",
+                    path.display(),
+                    source
+                )
+            }
+            Self::RequestFailed { source } => write!(f, "request failed: {}", source),
+            Self::UnexpectedResponseBody {
+                source,
+                response_body,
+                url,
+            } => write!(
+                f,
+                "unexpected response body: {}\nRequest from `{}`\n\nReceived body:\n{}",
+                source, url, response_body
+            ),
+            Self::NoCompatibleVersionFound {
+                tool,
+                available_versions,
+            } => {
+                write!(
+                    f,
+                    "no compatible version of {} was found for version requirement {}{}",
+                    tool.source(),
+                    tool.version(),
+                    if available_versions.is_empty() {
+                        "".to_owned()
+                    } else {
+                        format!(
+                            ". Available versions:\n* {}",
+                            available_versions
+                                .iter()
+                                .map(|version| version.to_string())
+                                .collect::<Vec<_>>()
+                                .join("\n* ")
+                        )
+                    }
+                )
+            }
+            Self::InvalidReleaseAsset {
+                tool,
+                version,
+                message,
+            } => write!(
+                f,
+                "invalid release asset for {} ({}): {}",
+                tool.source(),
+                version,
+                message
+            ),
+        }
+    }
+}
+
+const FOREMAN_CONFIG_HELP: &str = r#"A Foreman configuration file looks like this:
+
+[tools] # list the tools you want to install under this header
+
+# each tool is on its own line, the tool name is on the left
+# side of `=` and the right side tells Foreman where to find
+# it and which version to download
+tool_name = { github = "user/repository-name", version = "1.0.0" }
+
+# tools hosted on gitlab follows the same structure, except
+# `github` is replaced with `gitlab`
+
+# Examples:
+stylua = { github = "JohnnyMorganz/StyLua", version = "0.11.3" }
+darklua = { gitlab = "seaofvoices/darklua", version = "0.7.0" }"#;
+
+const FOREMAN_AUTH_HELP: &str = r#"A Foreman authentication file looks like this:
+
+# For authenticating with GitHub.com, put a personal access token here under the
+# `github` key. This is useful if you hit GitHub API rate limits or if you need
+# to access private tools.
+
+github = "YOUR_TOKEN_HERE"
+
+# For authenticating with GitLab.com, put a personal access token here under the
+# `gitlab` key. This is useful if you hit GitLab API rate limits or if you need
+# to access private tools.
+
+gitlab = "YOUR_TOKEN_HERE""#;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,227 +3,109 @@
 //! We won't use all these wrappers all the time, so it's okay if some of them
 //! are unused.
 
-#![allow(unused)]
-
 use std::{
-    error::Error as StdError,
-    fmt, fs,
-    io::{self, Read, Write},
-    path::{Path, PathBuf},
+    fs,
+    io::{self, BufWriter, Read},
+    path::Path,
 };
 
-pub type Result<T> = io::Result<T>;
-
-/// A wrapper around std::fs::read.
-pub fn read<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
+/// A wrapper around std::fs::read that returns None if the file does not exist.
+pub fn try_read<P: AsRef<Path>>(path: P) -> ForemanResult<Option<Vec<u8>>> {
     let path = path.as_ref();
 
-    fs::read(path).map_err(|source| Error::new(source, path))
+    match fs::read(&path).map(Some) {
+        Ok(contents) => Ok(contents),
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                Err(ForemanError::read_error(err, path))
+            }
+        }
+    }
 }
 
-/// A wrapper around std::fs::read_to_string.
-pub fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
+/// A wrapper around std::fs::read_to_string that returns None if the file does not exist.
+pub fn try_read_to_string<P: AsRef<Path>>(path: P) -> ForemanResult<Option<String>> {
     let path = path.as_ref();
 
-    fs::read_to_string(path).map_err(|source| Error::new(source, path))
+    match fs::read_to_string(&path).map(Some) {
+        Ok(contents) => Ok(contents),
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                Err(ForemanError::read_error(err, path))
+            }
+        }
+    }
+}
+
+/// A wrapper around std::fs::write that only writes if the file does not exist.
+pub fn write_if_not_found<P: AsRef<Path>, C: AsRef<[u8]>>(
+    path: P,
+    contents: C,
+) -> ForemanResult<()> {
+    let path = path.as_ref();
+
+    if let Err(err) = std::fs::metadata(&path) {
+        if err.kind() == io::ErrorKind::NotFound {
+            write(&path, contents)
+        } else {
+            Err(ForemanError::write_error(err, path))
+        }
+    } else {
+        Ok(())
+    }
 }
 
 /// A wrapper around std::fs::write.
-pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> ForemanResult<()> {
     let path = path.as_ref();
 
-    fs::write(path, contents).map_err(|source| Error::new(source, path))
+    fs::write(path, contents).map_err(|source| ForemanError::write_error(source, path))
 }
 
-/// A wrapper around std::fs::read.
-pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(source_path: P, dest_path: Q) -> Result<u64> {
+/// A wrapper around std::fs::copy.
+pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(source_path: P, dest_path: Q) -> ForemanResult<u64> {
     let source_path = source_path.as_ref();
     let dest_path = dest_path.as_ref();
 
     fs::copy(source_path, dest_path)
-        .map_err(|source| CopyError::new(source, source_path, dest_path))
+        .map_err(|source| ForemanError::copy_error(source, source_path, dest_path))
+}
+
+/// A wrapper around std::io::copy.
+pub fn copy_from_reader<R: Read + ?Sized, P: AsRef<Path>>(
+    reader: &mut R,
+    dest_path: P,
+) -> ForemanResult<u64> {
+    let dest_path = dest_path.as_ref();
+    let output_file = std::fs::File::create(&dest_path)
+        .map_err(|err| ForemanError::create_file_error(err, &dest_path))?;
+    let mut output = BufWriter::new(output_file);
+
+    io::copy(reader, &mut output).map_err(|err| ForemanError::write_error(err, &dest_path))
 }
 
 /// A wrapper around std::fs::create_dir_all.
 ///
 /// Currently reports all errors as happening from the given path.
-pub fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
+pub fn create_dir_all<P: AsRef<Path>>(path: P) -> ForemanResult<()> {
     let path = path.as_ref();
 
-    fs::create_dir_all(path).map_err(|source| Error::new(source, path))
-}
-
-/// A wrapper around std::fs::metadata.
-pub fn metadata<P: AsRef<Path>>(path: P) -> Result<fs::Metadata> {
-    let path = path.as_ref();
-
-    fs::metadata(path).map_err(|source| Error::new(source, path))
+    fs::create_dir_all(path).map_err(|source| ForemanError::write_error(source, path))
 }
 
 pub use fs::Permissions;
 
+use crate::error::{ForemanError, ForemanResult};
+
+#[cfg(unix)]
 /// A wrapper around std::fs::set_permissions
-pub fn set_permissions<P: AsRef<Path>>(path: P, permissions: Permissions) -> Result<()> {
+pub fn set_permissions<P: AsRef<Path>>(path: P, permissions: Permissions) -> ForemanResult<()> {
     let path = path.as_ref();
 
-    fs::set_permissions(path, permissions).map_err(|source| Error::new(source, path))
-}
-
-/// A wrapper around std::fs::File that contains file path information in error
-/// cases.
-#[derive(Debug)]
-pub struct File {
-    source: fs::File,
-    path: PathBuf,
-}
-
-impl File {
-    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let path = path.as_ref();
-        let source = fs::File::create(path).map_err(|source| Error::new(source, path))?;
-
-        Ok(Self {
-            source,
-            path: path.to_owned(),
-        })
-    }
-
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let path = path.as_ref();
-        let source = fs::File::open(path).map_err(|source| Error::new(source, path))?;
-
-        Ok(Self {
-            source,
-            path: path.to_owned(),
-        })
-    }
-}
-
-impl Read for File {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.source
-            .read(buf)
-            .map_err(|source| Error::new(source, &self.path))
-    }
-}
-
-impl Write for File {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.source
-            .write(buf)
-            .map_err(|source| Error::new(source, &self.path))
-    }
-
-    fn flush(&mut self) -> Result<()> {
-        self.source
-            .flush()
-            .map_err(|source| Error::new(source, &self.path))
-    }
-}
-
-/// Wrapper around std::fs::read_dir.
-pub fn read_dir<P: AsRef<Path>>(path: P) -> Result<ReadDir> {
-    let path = path.as_ref();
-
-    fs::read_dir(path)
-        .map(|source| ReadDir {
-            source,
-            path: path.to_owned(),
-        })
-        .map_err(|source| Error::new(source, path))
-}
-
-/// Wrapper around std::fs::ReadDir.
-pub struct ReadDir {
-    source: fs::ReadDir,
-    path: PathBuf,
-}
-
-impl Iterator for ReadDir {
-    type Item = Result<fs::DirEntry>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        Some(
-            self.source
-                .next()?
-                .map_err(|source| Error::new(source, &self.path)),
-        )
-    }
-}
-
-/// Contains an IO error that has a file path attached.
-///
-/// This type is never returned directly, but is instead wrapped inside yet
-/// another IO error.
-#[derive(Debug)]
-struct Error {
-    source: io::Error,
-    path: PathBuf,
-}
-
-impl Error {
-    fn new<P: Into<PathBuf>>(source: io::Error, path: P) -> io::Error {
-        io::Error::new(
-            source.kind(),
-            Self {
-                source,
-                path: path.into(),
-            },
-        )
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{} in path {}", self.source, self.path.display())
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&self.source)
-    }
-}
-
-/// Contains an IO error from a copy operation, containing both paths.
-#[derive(Debug)]
-struct CopyError {
-    source: io::Error,
-    source_path: PathBuf,
-    dest_path: PathBuf,
-}
-
-impl CopyError {
-    fn new<P: Into<PathBuf>, P2: Into<PathBuf>>(
-        source: io::Error,
-        source_path: P,
-        dest_path: P2,
-    ) -> io::Error {
-        io::Error::new(
-            source.kind(),
-            Self {
-                source,
-                source_path: source_path.into(),
-                dest_path: dest_path.into(),
-            },
-        )
-    }
-}
-
-impl fmt::Display for CopyError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "{} copying path {} to {}",
-            self.source,
-            self.source_path.display(),
-            self.dest_path.display()
-        )
-    }
-}
-
-impl StdError for CopyError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&self.source)
-    }
+    fs::set_permissions(path, permissions)
+        .map_err(|source| ForemanError::set_permission_error(source, path))
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,11 +1,8 @@
 //! Contains all of the paths that Foreman needs to deal with.
 
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use crate::{auth_store::DEFAULT_AUTH_CONFIG, fs};
+use crate::{auth_store::DEFAULT_AUTH_CONFIG, error::ForemanError, fs};
 
 static DEFAULT_USER_CONFIG: &str = include_str!("../resources/default-foreman.toml");
 
@@ -77,28 +74,16 @@ impl ForemanPaths {
         self.from_root("tool-cache.toml")
     }
 
-    pub fn create_all(&self) -> io::Result<()> {
+    pub fn create_all(&self) -> Result<(), ForemanError> {
         fs::create_dir_all(self.root_dir())?;
         fs::create_dir_all(self.bin_dir())?;
         fs::create_dir_all(self.tools_dir())?;
 
         let config = self.user_config();
-        if let Err(err) = fs::metadata(&config) {
-            if err.kind() == io::ErrorKind::NotFound {
-                fs::write(&config, DEFAULT_USER_CONFIG)?;
-            } else {
-                return Err(err);
-            }
-        }
+        fs::write_if_not_found(&config, DEFAULT_USER_CONFIG)?;
 
         let auth = self.auth_store();
-        if let Err(err) = fs::metadata(&auth) {
-            if err.kind() == io::ErrorKind::NotFound {
-                fs::write(&auth, DEFAULT_AUTH_CONFIG)?;
-            } else {
-                return Err(err);
-            }
-        }
+        fs::write_if_not_found(&auth, DEFAULT_AUTH_CONFIG)?;
 
         Ok(())
     }

--- a/src/tool_provider/github.rs
+++ b/src/tool_provider/github.rs
@@ -6,7 +6,11 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{auth_store::AuthStore, paths::ForemanPaths};
+use crate::{
+    auth_store::AuthStore,
+    error::{ForemanError, ForemanResult},
+    paths::ForemanPaths,
+};
 
 use super::{Release, ReleaseAsset, ToolProviderImpl};
 
@@ -22,35 +26,32 @@ impl GithubProvider {
 }
 
 impl ToolProviderImpl for GithubProvider {
-    fn get_releases(&self, repo: &str) -> reqwest::Result<Vec<Release>> {
-        log::debug!("Downloading github releases for {}", repo);
-
+    fn get_releases(&self, repo: &str) -> ForemanResult<Vec<Release>> {
         let client = Client::new();
 
         let url = format!("https://api.github.com/repos/{}/releases", repo);
         let mut builder = client.get(&url).header(USER_AGENT, "Roblox/foreman");
 
-        let auth_store = AuthStore::load(&self.paths.auth_store()).unwrap();
+        let auth_store = AuthStore::load(&self.paths.auth_store())?;
         if let Some(token) = &auth_store.github {
             builder = builder.header(AUTHORIZATION, format!("token {}", token));
         }
 
-        let response_body = builder.send()?.text()?;
+        log::debug!("Downloading github releases for {}", repo);
+        let response_body = builder
+            .send()
+            .map_err(ForemanError::request_failed)?
+            .text()
+            .map_err(ForemanError::request_failed)?;
 
-        let releases: Vec<GithubRelease> = match serde_json::from_str(&response_body) {
-            Ok(releases) => releases,
-            Err(err) => {
-                log::error!("Unexpected GitHub API response: {}", response_body);
-                panic!("{}", err);
-            }
-        };
+        let releases: Vec<GithubRelease> = serde_json::from_str(&response_body).map_err(|err| {
+            ForemanError::unexpected_response_body(err.to_string(), response_body, url)
+        })?;
 
         Ok(releases.into_iter().map(Into::into).collect())
     }
 
-    fn download_asset(&self, url: &str) -> reqwest::Result<Vec<u8>> {
-        log::debug!("Downloading release asset {}", url);
-
+    fn download_asset(&self, url: &str) -> ForemanResult<Vec<u8>> {
         let client = Client::new();
 
         let mut builder = client
@@ -60,15 +61,18 @@ impl ToolProviderImpl for GithubProvider {
             // release asset instead of JSON metadata about the release.
             .header(ACCEPT, "application/octet-stream");
 
-        let auth_store = AuthStore::load(&self.paths.auth_store()).unwrap();
+        let auth_store = AuthStore::load(&self.paths.auth_store())?;
         if let Some(token) = &auth_store.github {
             builder = builder.header(AUTHORIZATION, format!("token {}", token));
         }
 
-        let mut response = builder.send()?;
+        log::debug!("Downloading release asset {}", url);
+        let mut response = builder.send().map_err(ForemanError::request_failed)?;
 
         let mut output = Vec::new();
-        response.copy_to(&mut output)?;
+        response
+            .copy_to(&mut output)
+            .map_err(ForemanError::request_failed)?;
         Ok(output)
     }
 }

--- a/src/tool_provider/mod.rs
+++ b/src/tool_provider/mod.rs
@@ -6,12 +6,12 @@ use std::{collections::HashMap, fmt};
 use github::GithubProvider;
 use gitlab::GitlabProvider;
 
-use crate::paths::ForemanPaths;
+use crate::{error::ForemanResult, paths::ForemanPaths};
 
 pub trait ToolProviderImpl: fmt::Debug {
-    fn get_releases(&self, repo: &str) -> reqwest::Result<Vec<Release>>;
+    fn get_releases(&self, repo: &str) -> ForemanResult<Vec<Release>>;
 
-    fn download_asset(&self, url: &str) -> reqwest::Result<Vec<u8>>;
+    fn download_asset(&self, url: &str) -> ForemanResult<Vec<u8>>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/tests/snapshots/install_empty_config_file.snap
+++ b/tests/snapshots/install_empty_config_file.snap
@@ -1,9 +1,24 @@
 ---
 source: tests/cli.rs
-assertion_line: 94
+assertion_line: 101
 expression: content
 
 ---
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner: ErrorInner { kind: Custom, line: None, col: 0, at: None, message: "missing field `tools`", key: [] } }', src/config.rs:97:69
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+unable to parse Foreman configuration file (at {{CWD}}foreman.toml): missing field `tools`
+
+A Foreman configuration file looks like this:
+
+[tools] # list the tools you want to install under this header
+
+# each tool is on its own line, the tool name is on the left
+# side of `=` and the right side tells Foreman where to find
+# it and which version to download
+tool_name = { github = "user/repository-name", version = "1.0.0" }
+
+# tools hosted on gitlab follows the same structure, except
+# `github` is replaced with `gitlab`
+
+# Examples:
+stylua = { github = "JohnnyMorganz/StyLua", version = "0.11.3" }
+darklua = { gitlab = "seaofvoices/darklua", version = "0.7.0" }
 

--- a/tests/snapshots/install_invalid_auth_configuration.snap
+++ b/tests/snapshots/install_invalid_auth_configuration.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+assertion_line: 101
+expression: content
+
+---
+[INFO ] Downloading github.com/JohnnyMorganz/StyLua@^0.11.3
+unable to parse Foreman authentication file (at {{FOREMAN_HOME}}auth.toml): expected an equals, found eof at line 1 column 8
+
+A Foreman authentication file looks like this:
+
+# For authenticating with GitHub.com, put a personal access token here under the
+# `github` key. This is useful if you hit GitHub API rate limits or if you need
+# to access private tools.
+
+github = "YOUR_TOKEN_HERE"
+
+# For authenticating with GitLab.com, put a personal access token here under the
+# `gitlab` key. This is useful if you hit GitLab API rate limits or if you need
+# to access private tools.
+
+gitlab = "YOUR_TOKEN_HERE"
+

--- a/tests/snapshots/install_invalid_system_configuration.snap
+++ b/tests/snapshots/install_invalid_system_configuration.snap
@@ -4,7 +4,7 @@ assertion_line: 101
 expression: content
 
 ---
-unable to parse Foreman configuration file (at {{CWD}}foreman.toml): data did not match any variant of untagged enum ToolSpec for key `tools.tool` at line 2 column 1
+unable to parse Foreman configuration file (at {{FOREMAN_HOME}}foreman.toml): expected an equals, found eof at line 1 column 8
 
 A Foreman configuration file looks like this:
 


### PR DESCRIPTION
* create an error enum that implements Display
* replace unwraps by wrapping errors into a ForemanError
* refactor and simplify fs helpers to work with ForemanError

I had to touch a lot of code, but it's mostly trivial changes because it just adds `map_err` calls and change Result type annotations on functions.