### PR TITLE
Prefer 64-bit artifacts for windows/x86_64.

### DIFF
--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -1,5 +1,12 @@
-#[cfg(target_os = "windows")]
-static PLATFORM_KEYWORDS: &[&str] = &["win32", "win64", "windows"];
+#[cfg(all(target_os = "windows", target_arch = "x86"))]
+static PLATFORM_KEYWORDS: &[&str] = &["win32", "windows"];
+
+#[cfg(all(target_os = "windows", not(target_arch = "x86")))]
+static PLATFORM_KEYWORDS: &[&str] = &[
+	"win64",
+	"windows",
+	"win32",
+];
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 static PLATFORM_KEYWORDS: &[&str] = &["macos-x86_64", "darwin-x86_64", "macos", "darwin"];


### PR DESCRIPTION
If arch is 32-bit, then only 32-bit artifacts are detected. If arch is non-32-bit, then 32-bit artifacts are still included, but with reduced priority.

NOTE: I have no idea what I'm doing.