### PR TITLE
Support Go-style artifacts for Windows.

### DIFF
--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -1,11 +1,13 @@
 #[cfg(all(target_os = "windows", target_arch = "x86"))]
-static PLATFORM_KEYWORDS: &[&str] = &["win32", "windows"];
+static PLATFORM_KEYWORDS: &[&str] = &["win32", "windows-386", "windows"];
 
 #[cfg(all(target_os = "windows", not(target_arch = "x86")))]
 static PLATFORM_KEYWORDS: &[&str] = &[
 	"win64",
+	"windows-amd64",
 	"windows",
 	"win32",
+	"windows-386",
 ];
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]

--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -1,5 +1,12 @@
-#[cfg(target_os = "windows")]
-static PLATFORM_KEYWORDS: &[&str] = &["win32", "win64", "windows"];
+#[cfg(all(target_os = "windows", target_arch = "x86"))]
+static PLATFORM_KEYWORDS: &[&str] = &["win32", "windows"];
+
+#[cfg(all(target_os = "windows", not(target_arch = "x86")))]
+static PLATFORM_KEYWORDS: &[&str] = &[
+	"win64",
+	"windows",
+	"win32",
+];
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 static PLATFORM_KEYWORDS: &[&str] = &["macos-x86_64", "darwin-x86_64", "macos", "darwin"];


### PR DESCRIPTION
[Go](https://go.dev) uses `386` and `amd64` to target 32-bit and 64-bit architectures, respectively. This change includes these as artifacts for Windows targets.

Depends on #48. Not sure how stacked PRs work. 👍 🔥 💥 