### PR TITLE
Better error for missing install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Foreman Changelog
 
-## Unreleased Changes
+## 1.0.4 (2022-05-13)
+
+- Introduce improved error output on using uninstalled tools ([#51](https://github.com/Roblox/foreman/pull/51))
 - Add support for Apple Silicon (arm64) binaries ([#46](https://github.com/Roblox/foreman/pull/46))
 
 ## 1.0.3 (2022-02-04)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreman"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "assert_cmd",
  "command-group",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foreman"
 description = "Toolchain manager for simple binary tools"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
   "Lucien Greathouse <me@lpghatguy.com>",
   "Matt Hargett <plaztiksyke@gmail.com>",

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,16 @@ impl ConfigFile {
     }
 }
 
+impl fmt::Display for ConfigFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Available Tools:")?;
+        for (name, spec) in self.tools.iter() {
+            writeln!(f, "\t {} => {}", name, spec)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::{fmt, io, path::PathBuf};
 
 use semver::Version;
 
-use crate::config::ToolSpec;
+use crate::config::{ConfigFile, ToolSpec};
 
 pub type ForemanResult<T> = Result<T, ForemanError>;
 
@@ -62,6 +62,11 @@ pub enum ForemanError {
         tool: ToolSpec,
         version: Version,
         message: String,
+    },
+    ToolNotInstalled {
+        name: String,
+        current_path: PathBuf,
+        config_file: ConfigFile,
     },
 }
 
@@ -282,6 +287,20 @@ impl fmt::Display for ForemanError {
                 tool.source(),
                 version,
                 message
+            ),
+            Self::ToolNotInstalled {
+                name,
+                current_path,
+                config_file,
+            } => write!(
+                f,
+                "'{}' is not a known Foreman tool, but Foreman was invoked \
+                with its name.\n\nTo use this tool from {}, declare it in a \
+                'foreman.toml' file in the current directory or a parent \
+                directory.\n\n{}",
+                name,
+                current_path.display(),
+                config_file,
             ),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,13 +72,17 @@ impl ToolInvocation {
 
             Ok(())
         } else {
-            eprintln!(
-                "'{}' is not a known Foreman tool, but Foreman was invoked with its name.",
-                self.name
-            );
-            eprintln!("You may not have this tool installed here, or your install may be broken.");
-
-            Ok(())
+            let current_dir = env::current_dir().map_err(|err| {
+                ForemanError::io_error_with_context(
+                    err,
+                    "unable to obtain the current working directory",
+                )
+            })?;
+            Err(ForemanError::ToolNotInstalled {
+                name: self.name,
+                current_path: current_dir,
+                config_file: config,
+            })
         }
     }
 }

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -1,10 +1,8 @@
 ---
 source: tests/cli.rs
-assertion_line: 93
 expression: content
-
 ---
-foreman 1.0.3
+foreman 1.0.4
 
 USAGE:
     foreman [FLAGS] <SUBCOMMAND>


### PR DESCRIPTION
Better elaboration for a common error where a foreman-managed tool is being used outside of a scope in which it's been defined as a tool dependency.

Old error looked like this:
```
pdoyle:~/dev/projects/foreman (better-error-for-missing-install)
$ selene
'selene' is not a known Foreman tool, but Foreman was invoked with its name.
You may not have this tool installed here, or your install may be broken.
```

New error looks like this:
```
pdoyle:~/dev/projects/foreman (better-error-for-missing-install)
$ selene
'selene' is not a known Foreman tool, but Foreman was invoked with its name.

To use this tool from C:\Users\pdoyle\dev\projects\foreman, declare it in a 'foreman.toml' file in the current directory or a parent directory.

Available Tools:
         rojo => github.com/rojo-rbx/rojo@^6.0
         stylua => github.com/johnnymorganz/stylua@^0.13.0
         darklua => gitlab.com/seaofvoices/darklua@^0.7.0
```

Additionally, this tees up a 1.0.4 release.