### PR TITLE
Fix artifact selection bug

### DIFF
--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -239,7 +239,6 @@ mod test {
     // Regression test for LUAFDN-1041, based on the release that surfaced it
     #[test]
     fn select_correct_asset() {
-        let platform_keywords = &["macos-x86_64", "darwin-x86_64", "macos", "darwin"];
         let release = Release {
             prerelease: false,
             tag_name: "v0.5.2".to_string(),
@@ -262,7 +261,17 @@ mod test {
                 },
             ],
         };
-        assert_eq!(choose_asset(&release, platform_keywords), Some(2));
+        assert_eq!(choose_asset(&release, &["win32", "win64", "windows"]), Some(3));
+        assert_eq!(choose_asset(&release, &["macos-x86_64", "darwin-x86_64", "macos", "darwin"]), Some(2));
+        assert_eq!(choose_asset(&release, &[
+            "macos-arm64",
+            "darwin-arm64",
+            "macos-x86_64",
+            "darwin-x86_64",
+            "macos",
+            "darwin",
+        ]), Some(1));
+        assert_eq!(choose_asset(&release, &["linux"]), Some(0));
     }
 
     mod load {

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -109,12 +109,14 @@ impl ToolCache {
                     Version::parse(&release.tag_name[1..]).ok()
                 })?;
 
+                log::trace!("Checking for name with compatible os/arch pair from platform-derived list: {:?}", platform_keywords());
                 let asset_index = release.assets.iter().position(|asset| {
                     platform_keywords()
                         .iter()
                         .any(|keyword| asset.name.contains(keyword))
                 })?;
 
+                log::debug!("Found matching artifact: {}", release.assets[asset_index].name);
                 Some((version, asset_index, release))
             })
             .collect();

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -18,7 +18,7 @@ use crate::{
     error::{ForemanError, ForemanResult},
     fs,
     paths::ForemanPaths,
-    tool_provider::{ToolProvider, Release},
+    tool_provider::{Release, ToolProvider},
 };
 
 fn choose_asset(release: &Release, platform_keywords: &[&str]) -> Option<usize> {
@@ -27,10 +27,16 @@ fn choose_asset(release: &Release, platform_keywords: &[&str]) -> Option<usize> 
         platform_keywords
     );
     let asset_index = platform_keywords.iter().find_map(|keyword| {
-        release.assets.iter().position(|asset| asset.name.contains(keyword))
+        release
+            .assets
+            .iter()
+            .position(|asset| asset.name.contains(keyword))
     })?;
 
-    log::debug!("Found matching artifact: {}", release.assets[asset_index].name);
+    log::debug!(
+        "Found matching artifact: {}",
+        release.assets[asset_index].name
+    );
     Some(asset_index)
 }
 
@@ -261,16 +267,31 @@ mod test {
                 },
             ],
         };
-        assert_eq!(choose_asset(&release, &["win32", "win64", "windows"]), Some(3));
-        assert_eq!(choose_asset(&release, &["macos-x86_64", "darwin-x86_64", "macos", "darwin"]), Some(2));
-        assert_eq!(choose_asset(&release, &[
-            "macos-arm64",
-            "darwin-arm64",
-            "macos-x86_64",
-            "darwin-x86_64",
-            "macos",
-            "darwin",
-        ]), Some(1));
+        assert_eq!(
+            choose_asset(&release, &["win32", "win64", "windows"]),
+            Some(3)
+        );
+        assert_eq!(
+            choose_asset(
+                &release,
+                &["macos-x86_64", "darwin-x86_64", "macos", "darwin"]
+            ),
+            Some(2)
+        );
+        assert_eq!(
+            choose_asset(
+                &release,
+                &[
+                    "macos-arm64",
+                    "darwin-arm64",
+                    "macos-x86_64",
+                    "darwin-x86_64",
+                    "macos",
+                    "darwin",
+                ]
+            ),
+            Some(1)
+        );
         assert_eq!(choose_asset(&release, &["linux"]), Some(0));
     }
 

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -26,10 +26,8 @@ fn choose_asset(release: &Release, platform_keywords: &[&str]) -> Option<usize> 
         "Checking for name with compatible os/arch pair from platform-derived list: {:?}",
         platform_keywords
     );
-    let asset_index = release.assets.iter().position(|asset| {
-        platform_keywords
-            .iter()
-            .any(|keyword| asset.name.contains(keyword))
+    let asset_index = platform_keywords.iter().find_map(|keyword| {
+        release.assets.iter().position(|asset| asset.name.contains(keyword))
     })?;
 
     log::debug!("Found matching artifact: {}", release.assets[asset_index].name);
@@ -238,7 +236,7 @@ mod test {
 
     use super::*;
 
-    // Regression test for LUAFDN-1041
+    // Regression test for LUAFDN-1041, based on the release that surfaced it
     #[test]
     fn select_correct_asset() {
         let platform_keywords = &["macos-x86_64", "darwin-x86_64", "macos", "darwin"];


### PR DESCRIPTION
Artifact selection uses an outer loop over all assets, and an inner loop over possible valid names. This means that it will pick the first asset that matches _any_ valid names, instead of the best match for the earliest name in the list.

The fix should just be to switch the loops!