### PR TITLE
Fix macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ["*"]
 
+  pull_request:
+    branches:
+    - master
 jobs:
   windows:
     runs-on: windows-latest
@@ -76,6 +79,7 @@ jobs:
         path: target/release/foreman
 
   release:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: ['windows', 'macos', 'linux']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags: ["*"]
 
-  pull_request:
-    branches:
-    - master
 jobs:
   windows:
     runs-on: windows-latest
@@ -79,7 +76,6 @@ jobs:
         path: target/release/foreman
 
   release:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: ['windows', 'macos', 'linux']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Cleanup finished x86_64 build
       run: rm -rf ./target
 
-    - name: Build aarch64 release binary
+    - name: Build arm64 release binary
       run: |
         source $HOME/.cargo/env
         cargo build --verbose --locked --release --target aarch64-apple-darwin
@@ -60,7 +60,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: foreman-macos-arm64
-        path: target/arm64-apple-darwin/release/foreman
+        path: target/aarch64-apple-darwin/release/foreman
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
         name: foreman-macos-x86_64
         path: target/x86_64-apple-darwin/release/foreman
 
+    - name: Cleanup finished x86_64 build
+      run: rm -rf ./target
+
     - name: Build aarch64 release binary
       run: |
         source $HOME/.cargo/env


### PR DESCRIPTION
Fix typo in the artifact upload path for aarch64 build 
Add cleanup of the x86 artifacts to ensure architectures are not mixed up