### PR TITLE
Take into account architecture when selecting linux artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Foreman Changelog
 
+## Unreleased
+
+- Take into account architecture when downloading binaries for linux ([#59](https://github.com/Roblox/foreman/pull/59))
+
 ## 1.0.4 (2022-05-13)
 
 - Introduce improved error output on using uninstalled tools ([#51](https://github.com/Roblox/foreman/pull/51))

--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -14,8 +14,11 @@ static PLATFORM_KEYWORDS: &[&str] = &[
     "darwin",
 ];
 
-#[cfg(target_os = "linux")]
-static PLATFORM_KEYWORDS: &[&str] = &["linux"];
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+static PLATFORM_KEYWORDS: &[&str] = &["linux-x86_64", "linux"];
+
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+static PLATFORM_KEYWORDS: &[&str] = &["linux-arm64", "linux-aarch64", "linux"];
 
 pub fn platform_keywords() -> &'static [&'static str] {
     PLATFORM_KEYWORDS

--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -20,6 +20,12 @@ static PLATFORM_KEYWORDS: &[&str] = &["linux-x86_64", "linux"];
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 static PLATFORM_KEYWORDS: &[&str] = &["linux-arm64", "linux-aarch64", "linux"];
 
+#[cfg(all(
+    target_os = "linux",
+    not(any(target_arch = "x86_64", target_arch = "aarch64"))
+))]
+static PLATFORM_KEYWORDS: &[&str] = &["linux"];
+
 pub fn platform_keywords() -> &'static [&'static str] {
     PLATFORM_KEYWORDS
 }

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -295,6 +295,38 @@ mod test {
         assert_eq!(choose_asset(&release, &["linux"]), Some(0));
     }
 
+    #[test]
+    fn select_correct_asset_linux() {
+        let release = Release {
+            prerelease: false,
+            tag_name: "v0.5.2".to_string(),
+            assets: vec![
+                ReleaseAsset {
+                    name: "tool-linux-aarch64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/1".to_string(),
+                },
+                ReleaseAsset {
+                    name: "tool-linux-x86_64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/2".to_string(),
+                },
+                ReleaseAsset {
+                    name: "tool-macos-x86_64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/3".to_string(),
+                },
+                ReleaseAsset {
+                    name: "tool-win64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/4".to_string(),
+                },
+            ],
+        };
+        assert_eq!(choose_asset(&release, &["linux"]), Some(0));
+        assert_eq!(choose_asset(&release, &["linux-x86_64", "linux"]), Some(1));
+        assert_eq!(
+            choose_asset(&release, &["linux-arm64", "linux-aarch64", "linux"]),
+            Some(0)
+        );
+    }
+
     mod load {
         use super::*;
 


### PR DESCRIPTION
StyLua recently started producing `linux-aarch64` builds. Foreman does not correctly take into account the architecture on linux, and selects the `linux-aarch64` build when `linux-x86_64` should be used. This causes GitHub Actions CI to fail.

We fix this by preferring a more explicit name in platform keywords for linux (depending on arch), and falling back to the generic one if nothing is found