### PR TITLE
Support `macos-aarch64` as a platform keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Foreman Changelog
 
+## Unreleased
+
+- Support `macos-aarch64` as an artifact name for Apple Silicon (arm64) binaries ([#60](https://github.com/Roblox/foreman/pull/60))
+
 ## 1.0.4 (2022-05-13)
 
 - Introduce improved error output on using uninstalled tools ([#51](https://github.com/Roblox/foreman/pull/51))

--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -8,6 +8,8 @@ static PLATFORM_KEYWORDS: &[&str] = &["macos-x86_64", "darwin-x86_64", "macos", 
 static PLATFORM_KEYWORDS: &[&str] = &[
     "macos-arm64",
     "darwin-arm64",
+    "macos-aarch64",
+    "darwin-aarch64",
     "macos-x86_64",
     "darwin-x86_64",
     "macos",

--- a/src/artifact_choosing.rs
+++ b/src/artifact_choosing.rs
@@ -10,8 +10,6 @@ static PLATFORM_KEYWORDS: &[&str] = &[
     "darwin-arm64",
     "macos-aarch64",
     "darwin-aarch64",
-    "macos-x86_64",
-    "darwin-x86_64",
     "macos",
     "darwin",
 ];

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -295,6 +295,44 @@ mod test {
         assert_eq!(choose_asset(&release, &["linux"]), Some(0));
     }
 
+    #[test]
+    fn select_correct_asset_macos() {
+        let release = Release {
+            prerelease: false,
+            tag_name: "v0.5.2".to_string(),
+            assets: vec![
+                ReleaseAsset {
+                    name: "tool-linux.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/1".to_string(),
+                },
+                ReleaseAsset {
+                    name: "tool-macos-x86_64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/2".to_string(),
+                },
+                ReleaseAsset {
+                    name: "tool-macos-aarch64.zip".to_string(),
+                    url: "https://example.com/some/repo/releases/assets/3".to_string(),
+                },
+            ],
+        };
+        assert_eq!(
+            choose_asset(
+                &release,
+                &[
+                    "macos-arm64",
+                    "darwin-arm64",
+                    "macos-aarch64",
+                    "darwin-aarch64",
+                    "macos-x86_64",
+                    "darwin-x86_64",
+                    "macos",
+                    "darwin",
+                ]
+            ),
+            Some(2)
+        );
+    }
+
     mod load {
         use super::*;
 

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -323,8 +323,6 @@ mod test {
                     "darwin-arm64",
                     "macos-aarch64",
                     "darwin-aarch64",
-                    "macos-x86_64",
-                    "darwin-x86_64",
                     "macos",
                     "darwin",
                 ]


### PR DESCRIPTION
StyLua produces macOS M1 binaries using the `macos-aarch64` name, rather than `macos-arm64`.

We add in `macos-aarch64` as a platform keyword so it doesn't fall back to the Rosetta x86_64 binary