### PR TITLE
Implement anti-duplicate parsing for config.tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.53.0"]
+        rust_version: [stable, "1.58.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Foreman Changelog
 
+## Unreleased
+- Errors when duplicate tools are defined in `foreman.toml` ([#65](https://github.com/Roblox/foreman/pull/65))
+
 ## 1.0.6 (2022-09-28)
 
 - Support `macos-aarch64` as an artifact name for Apple Silicon (arm64) binaries ([#60](https://github.com/Roblox/foreman/pull/60))

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,7 +190,7 @@ impl<'de> Visitor<'de> for ConfigFileVisitor {
             if tools.contains_key(&key) {
                 // item already existed inside the config
                 // throw an error as this is unlikely to be the users intention
-                return Err(de::Error::custom(format!("duplicate tool `{key}`")));
+                return Err(de::Error::custom(format!("duplicate tool name `{key}` found")));
             }
 
             tools.insert(key, value);

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,7 +190,9 @@ impl<'de> Visitor<'de> for ConfigFileVisitor {
             if tools.contains_key(&key) {
                 // item already existed inside the config
                 // throw an error as this is unlikely to be the users intention
-                return Err(de::Error::custom(format!("duplicate tool name `{key}` found")));
+                return Err(de::Error::custom(format!(
+                    "duplicate tool name `{key}` found"
+                )));
             }
 
             tools.insert(key, value);
@@ -268,7 +270,34 @@ mod test {
             )
             .unwrap_err();
 
-            assert_eq!(err.to_string(), "duplicate tool `tool` at line 1 column 1");
+            assert_eq!(
+                err.to_string(),
+                "duplicate tool name `tool` found at line 1 column 1"
+            );
+
+            let err = toml::from_str::<ConfigFileTools>(
+                r#"tool_a = { github = "user/a", version = "0.1.0" }
+			tool_b = { github = "user/b", version = "0.2.0" }
+			tool_a = { gitlab = "user/c", version = "0.3.0" }"#,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                err.to_string(),
+                "duplicate tool name `tool_a` found at line 1 column 1"
+            );
+
+            let err = toml::from_str::<ConfigFileTools>(
+                r#"tool_b = { github = "user/b", version = "0.1.0" }
+			tool_a = { github = "user/a", version = "0.2.0" }
+			tool_a = { gitlab = "user/c", version = "0.3.0" }"#,
+            )
+            .unwrap_err();
+
+            assert_eq!(
+                err.to_string(),
+                "duplicate tool name `tool_a` found at line 1 column 1"
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn actual_main(paths: ForemanPaths) -> ForemanResult<()> {
 
             let mut cache = ToolCache::load(&paths)?;
 
-            for (tool_alias, tool_spec) in &config.tools {
+            for (tool_alias, tool_spec) in config.tools.iter() {
                 let providers = ToolProvider::new(&paths);
                 cache.download_if_necessary(tool_spec, &providers)?;
                 add_self_alias(tool_alias, &paths.bin_dir())?;


### PR DESCRIPTION
During deserialization, ensures that there are no duplicate entries in config.tools. By default, serde will overwrite duplicate entries when deserializing to a HashMap<K, V>.

In almost all cases, a user would be incorrectly doing so accidentally, so we now throw an error when parsing the configuration file.

A unit test has been implemented to test the logic of this deserialization for duplicate tool entries.
```toml
tool = { github = "user/repo", version = "0.1.0" }
tool = { github = "user2/repo2", version = "0.2.0" }
```
will error with
```
duplicate tool `tool` at line 1 column 1
```

Closes #63 