### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+## 1.2.0 (2023-08-02)
 - Take into account architecture when downloading binaries for Windows to fix incorrect download of windows-aarch64 assets on win64 hosts ([#71](https://github.com/Roblox/foreman/pull/71))
 - Support all Tier 1 Rust supported platforms {windows, linux, macos}-{x86_64, i686, aarch64} ([#71](https://github.com/Roblox/foreman/pull/71))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreman"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "assert_cmd",
  "command-group",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foreman"
 description = "Toolchain manager for simple binary tools"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
   "Lucien Greathouse <me@lpghatguy.com>",
   "Matt Hargett <plaztiksyke@gmail.com>",

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -2,7 +2,7 @@
 source: tests/cli.rs
 expression: content
 ---
-foreman 1.1.0
+foreman 1.2.0
 
 USAGE:
     foreman [FLAGS] <SUBCOMMAND>


### PR DESCRIPTION
Since `setup-foreman` takes the latest stable by default, the release will be initially labeled as a prerelease so we can validate CI workflows.