### PR TITLE
Modified path to follow symlinks for snapshots tests

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -118,11 +118,7 @@ fn working_directory_display(dir: &TempDir) -> String {
 
 #[cfg(target_os = "windows")]
 fn working_directory_display(dir: &TempDir) -> String {
-    format!(
-        "{}{}",
-        dir.path().display(),
-        std::path::MAIN_SEPARATOR
-    )
+    format!("{}{}", dir.path().display(), std::path::MAIN_SEPARATOR)
 }
 
 fn write_file(path: &Path, content: &str) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsStr,
-    fs::read_to_string,
+    fs::{canonicalize, read_to_string},
     path::{Path, PathBuf},
 };
 
@@ -36,7 +36,12 @@ impl TestContext {
         );
         let working_directory_display = format!(
             "{}{}",
-            working_directory.path().display(),
+            canonicalize(&working_directory)
+                .expect(
+                    "
+        unable to locate working directory",
+                )
+                .display(),
             std::path::MAIN_SEPARATOR
         );
         Self {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -113,7 +113,7 @@ fn working_directory_display(dir: &TempDir) -> String {
             )
             .display(),
         std::path::MAIN_SEPARATOR
-    );
+    )
 }
 
 #[cfg(target_os = "windows")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,11 @@
 use std::{
     ffi::OsStr,
-    fs::{canonicalize, read_to_string},
+    fs::read_to_string,
     path::{Path, PathBuf},
 };
+
+#[allow(unused_imports)]
+use std::fs::canonicalize;
 
 use assert_cmd::Command;
 use insta::assert_snapshot;
@@ -34,16 +37,7 @@ impl TestContext {
             home_directory.path().display(),
             std::path::MAIN_SEPARATOR
         );
-        let working_directory_display = format!(
-            "{}{}",
-            canonicalize(&working_directory)
-                .expect(
-                    "
-        unable to locate working directory",
-                )
-                .display(),
-            std::path::MAIN_SEPARATOR
-        );
+        let working_directory_display = working_directory_display(&working_directory);
         Self {
             command,
             home_directory,
@@ -106,6 +100,29 @@ impl TestContext {
             assert_snapshot!(snapshot_name, content);
         });
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn working_directory_display(dir: &TempDir) -> String {
+    format!(
+        "{}{}",
+        canonicalize(dir)
+            .expect(
+                "
+    unable to locate working directory",
+            )
+            .display(),
+        std::path::MAIN_SEPARATOR
+    );
+}
+
+#[cfg(target_os = "windows")]
+fn working_directory_display(dir: &TempDir) -> String {
+    format!(
+        "{}{}",
+        dir.path().display(),
+        std::path::MAIN_SEPARATOR
+    )
 }
 
 fn write_file(path: &Path, content: &str) {


### PR DESCRIPTION
Some snapshot tests were failing on m2 macs due to a difference between "/private/vars/folders..." and "/vars/folders...". "/vars/folders..." seems to just by a symlink to "/private/vars/folders...", so the file path was changed to follow said symlinks