### PR TITLE
LUAFDN-1756 Manual deserialization of toml into toolspec struct

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use semver::Version;
 use crate::config::{ConfigFile, ToolSpec};
 
 pub type ForemanResult<T> = Result<T, ForemanError>;
-
+pub type ConfigFileParseResult<T> = Result<T, ConfigFileParseError>;
 #[derive(Debug)]
 pub enum ForemanError {
     IO {
@@ -71,6 +71,12 @@ pub enum ForemanError {
     ToolsNotDownloaded {
         tools: Vec<String>,
     },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ConfigFileParseError {
+    MissingField { field: String },
+    Tool { tool: String },
 }
 
 impl ForemanError {
@@ -307,6 +313,17 @@ impl fmt::Display for ForemanError {
             ),
             Self::ToolsNotDownloaded { tools } => {
                 write!(f, "The following tools were not installed:\n{:#?}", tools)
+            }
+        }
+    }
+}
+
+impl fmt::Display for ConfigFileParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingField { field } => write!(f, "missing field `{}`", field),
+            Self::Tool { tool } => {
+                write!(f, "data is not properly formatted for tool:\n\n{}", tool)
             }
         }
     }

--- a/src/tool_cache.rs
+++ b/src/tool_cache.rs
@@ -107,7 +107,7 @@ impl ToolCache {
         log::info!("Downloading {}", tool);
 
         let provider = providers.get(&tool.provider());
-        let releases = provider.get_releases(tool.source())?;
+        let releases = provider.get_releases(tool.path())?;
 
         // Filter down our set of releases to those that are valid versions and
         // have release assets for our current platform.

--- a/src/tool_provider/mod.rs
+++ b/src/tool_provider/mod.rs
@@ -3,10 +3,9 @@ mod gitlab;
 
 use std::{collections::HashMap, fmt};
 
+use crate::{error::ForemanResult, paths::ForemanPaths};
 use github::GithubProvider;
 use gitlab::GitlabProvider;
-
-use crate::{error::ForemanResult, paths::ForemanPaths};
 
 pub trait ToolProviderImpl: fmt::Debug {
     fn get_releases(&self, repo: &str) -> ForemanResult<Vec<Release>>;

--- a/tests/snapshots/install_invalid_tool_configuration.snap
+++ b/tests/snapshots/install_invalid_tool_configuration.snap
@@ -4,7 +4,12 @@ assertion_line: 101
 expression: content
 
 ---
-unable to parse Foreman configuration file (at {{CWD}}foreman.toml): data did not match any variant of untagged enum ToolSpec for key `tools.tool` at line 2 column 1
+unable to parse Foreman configuration file (at {{CWD}}foreman.toml): data is not properly formatted for tool:
+
+[tools.tool]
+invalid = "roblox/tooling"
+version = "0.0.0"
+
 
 A Foreman configuration file looks like this:
 


### PR DESCRIPTION
Making ToolSpec more generic to support other sources (specifically Artifactory) by changing it from an enum into a struct. We can't rely on Serde to deserialize the toml into a struct, so we need to deserialize it ourselves