### PR TITLE
Add command to add Artifactory Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreman"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "artiaa_auth",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = [".", "artiaa_auth"]
 [package]
 name = "foreman"
 description = "Toolchain manager for simple binary tools"
-version = "1.5.0"
+version = "1.6.0"
 authors = [
     "Lucien Greathouse <me@lpghatguy.com>",
     "Matt Hargett <plaztiksyke@gmail.com>",

--- a/src/artifactory_auth_store.rs
+++ b/src/artifactory_auth_store.rs
@@ -1,0 +1,72 @@
+use crate::error::ForemanError;
+use crate::{error::ForemanResult, fs};
+use artiaa_auth::{error::ArtifactoryAuthError, Credentials};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use std::{
+    ops::{Deref, DerefMut},
+    path::Path,
+};
+/// Contains stored user tokens that Foreman can use to download tools.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ArtifactoryAuthStore {
+    tokens: HashMap<String, Credentials>,
+}
+
+impl Deref for ArtifactoryAuthStore {
+    type Target = HashMap<String, Credentials>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tokens
+    }
+}
+
+impl DerefMut for ArtifactoryAuthStore {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.tokens
+    }
+}
+
+impl ArtifactoryAuthStore {
+    pub fn set_token(auth_file: &Path, key: &str, token: &str) -> ForemanResult<()> {
+        let contents = fs::try_read_to_string(auth_file)?;
+
+        let mut store: ArtifactoryAuthStore = if let Some(contents) = contents {
+            serde_json::from_str(&contents).map_err(|err: serde_json::Error| {
+                ForemanError::ArtiAAError {
+                    error: ArtifactoryAuthError::auth_parsing(auth_file, err.to_string()),
+                }
+            })?
+        } else {
+            ArtifactoryAuthStore::default()
+        };
+
+        store.insert(
+            key.to_owned(),
+            Credentials {
+                username: "".to_owned(),
+                token: token.to_owned(),
+            },
+        );
+
+        let serialized =
+            serde_json::to_string_pretty(&store).map_err(|err: serde_json::Error| {
+                ForemanError::ArtiAAError {
+                    error: ArtifactoryAuthError::auth_parsing(auth_file, err.to_string()),
+                }
+            })?;
+
+        if let Some(dir) = auth_file.parent() {
+            fs::create_dir_all(dir)?;
+            fs::write(auth_file, serialized)
+        } else {
+            Err(ForemanError::ArtiAAError {
+                error: ArtifactoryAuthError::auth_parsing(
+                    auth_file,
+                    "Could not find parent directory of auth file".to_owned(),
+                ),
+            })
+        }
+    }
+}

--- a/src/tool_provider/artifactory.rs
+++ b/src/tool_provider/artifactory.rs
@@ -1,4 +1,4 @@
-//! Slice of GitHub's API that Foreman consumes.
+//! Slice of Artifactory's API that Foreman consumes.
 
 use super::{Release, ReleaseAsset, ToolProviderImpl};
 use crate::{

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -1,8 +1,9 @@
 ---
 source: tests/cli.rs
+assertion_line: 100
 expression: content
 ---
-foreman 1.5.0
+foreman 1.6.0
 
 USAGE:
     foreman [FLAGS] <SUBCOMMAND>
@@ -13,6 +14,7 @@ FLAGS:
     -v               Logging verbosity. Supply multiple for more verbosity, up to -vvv
 
 SUBCOMMANDS:
+    artifactory-auth             Set the Artifactory Token that Foreman should use with the Artifactory API
     generate-artifactory-path    Create a path to publish to artifactory
     github-auth                  Set the GitHub Personal Access Token that Foreman should use with the GitHub API
     gitlab-auth                  Set the GitLab Personal Access Token that Foreman should use with the GitLab API


### PR DESCRIPTION
We can already read Artifactory tokens, but Foreman has no way of adding the tokens them itself. This PR looks to add the command `artifactory-auth`, that places the tokens in the expected format in the expected location.

This PR also includes a minor version bump since we are adding behavior.