### PR TITLE
Change artifactory authorization to bearer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreman"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "artiaa_auth",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = [".", "artiaa_auth"]
 [package]
 name = "foreman"
 description = "Toolchain manager for simple binary tools"
-version = "1.6.1"
+version = "1.6.2"
 authors = [
     "Lucien Greathouse <me@lpghatguy.com>",
     "Matt Hargett <plaztiksyke@gmail.com>",

--- a/src/tool_provider/artifactory.rs
+++ b/src/tool_provider/artifactory.rs
@@ -40,7 +40,7 @@ impl ToolProviderImpl for ArtifactoryProvider {
             .map_err(|error| ForemanError::ArtiAAError { error })?;
 
         if let Some(credentials) = tokens.get_credentials(host) {
-            builder = builder.header(AUTHORIZATION, format! {"Bearer {}", credentials.token});
+            builder = builder.header(AUTHORIZATION, format!("Bearer {}", credentials.token));
         }
         log::debug!("Downloading artifactory releases for {}", repo);
         let response_body = builder

--- a/src/tool_provider/artifactory.rs
+++ b/src/tool_provider/artifactory.rs
@@ -14,8 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 
-const ARTIFACTORY_API_KEY_HEADER: &str = "X-JFrog-Art-Api";
-
 #[derive(Debug)]
 pub struct ArtifactoryProvider {
     paths: ForemanPaths,
@@ -42,7 +40,7 @@ impl ToolProviderImpl for ArtifactoryProvider {
             .map_err(|error| ForemanError::ArtiAAError { error })?;
 
         if let Some(credentials) = tokens.get_credentials(host) {
-            builder = builder.header(ARTIFACTORY_API_KEY_HEADER, credentials.token.to_string());
+            builder = builder.header(AUTHORIZATION, format!{"Bearer {}", credentials.token.to_string()});
         }
         log::debug!("Downloading artifactory releases for {}", repo);
         let response_body = builder
@@ -98,7 +96,7 @@ impl ToolProviderImpl for ArtifactoryProvider {
 
         let tokens = artiaa_auth::Tokens::load(&self.paths.artiaa_path()?).unwrap();
         if let Some(credentials) = tokens.get_credentials(&artifactory_url) {
-            builder = builder.header(AUTHORIZATION, format!("bearer {}", credentials.token));
+            builder = builder.header(AUTHORIZATION, format!("Bearer {}", credentials.token));
         }
 
         log::debug!("Downloading release asset {}", url);

--- a/src/tool_provider/artifactory.rs
+++ b/src/tool_provider/artifactory.rs
@@ -40,7 +40,7 @@ impl ToolProviderImpl for ArtifactoryProvider {
             .map_err(|error| ForemanError::ArtiAAError { error })?;
 
         if let Some(credentials) = tokens.get_credentials(host) {
-            builder = builder.header(AUTHORIZATION, format!{"Bearer {}", credentials.token.to_string()});
+            builder = builder.header(AUTHORIZATION, format! {"Bearer {}", credentials.token});
         }
         log::debug!("Downloading artifactory releases for {}", repo);
         let response_body = builder

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -3,7 +3,7 @@ source: tests/cli.rs
 assertion_line: 100
 expression: content
 ---
-foreman 1.6.1
+foreman 1.6.2
 
 USAGE:
     foreman [FLAGS] <SUBCOMMAND>


### PR DESCRIPTION
According to https://jfrog.com/help/r/jfrog-platform-administration-documentation/api-key, API keys are being deprecated and we should be using Bearer authentication

Also bumping version to 1.6.2 for small patch release