### PR TITLE
Add readme to artiaa_auth and bump foreman version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreman"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "artiaa_auth",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = [".", "artiaa_auth"]
 [package]
 name = "foreman"
 description = "Toolchain manager for simple binary tools"
-version = "1.6.2"
+version = "1.6.3"
 authors = [
     "Lucien Greathouse <me@lpghatguy.com>",
     "Matt Hargett <plaztiksyke@gmail.com>",

--- a/artiaa_auth/README.md
+++ b/artiaa_auth/README.md
@@ -1,0 +1,35 @@
+# artiaa_auth
+Reads artifactory authentication using the following schema:
+
+```
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "title": "ArtiAA Token File Format",
+  "description": "This is the format of the ArtiAA Token File, a standard output that contains the Artifactory tokens for the user. ",
+  "properties": {
+    "tokens": {
+      "title": "Tokens URL Map",
+      "description": "Map of URLs and the credentials that apply to them.\nThe key of each value is the base domain URL the credential applies to, such as 'artifactory.rbx.com'.\nArtiAA will add an entry for each URL it has been logged into.",
+      "type": "object",
+      "additionalProperties": {
+        "title": "URL Token Element",
+        "type": "object",
+        "properties": {
+          "username": {
+            "title": "Username",
+            "description": "The username to use for accessing the server, if a username is necessary.\nMay be an empty string.",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "description": "The token to use for accessing the server.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}
+```

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -3,7 +3,7 @@ source: tests/cli.rs
 assertion_line: 100
 expression: content
 ---
-foreman 1.6.2
+foreman 1.6.3
 
 USAGE:
     foreman [FLAGS] <SUBCOMMAND>


### PR DESCRIPTION
This PR looks to add readme to artiaa_auth so we can publish it as an individual crate for Foreman to depend on