### PR TITLE
Update README.md To Use Tokens (classic) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ export PATH=$HOME/.foreman/bin:$PATH
 ### Authentication
 To install tools from a private GitHub repository, Foreman supports authenticating with a [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). When creating the token in GitHub:
 
-1. Make sure to configure the token to have access to the `repo` scope
-2. Once created, you may need to click the `Configure SSO` button next to the token to authorize it for SSO usage. Whether or not you need to do this will depend on the GitHub org that you need to access.
+1. Make sure to create a `Tokens (classic)` Personal Access Token. Fine-grained tokens may not work properly.
+2. Make sure to configure the token to have access to the `repo` scope.
+3. Once created, you may need to click the `Configure SSO` button next to the token to authorize it for SSO usage. Whether or not you need to do this will depend on the GitHub org that you need to access.
 
 Use `foreman github-auth` to pass an authentication token to Foreman, or open `~/.foreman/auth.toml` and follow the contained instructions.
 

--- a/scripts/end-to-end-tests.sh
+++ b/scripts/end-to-end-tests.sh
@@ -55,7 +55,7 @@ verify_install_all_before_fail () {
 verify_github_tool Rojo "rojo-rbx/rojo" "7.3.0"
 verify_github_tool remodel "rojo-rbx/remodel" "0.11.0"
 verify_github_tool stylua "JohnnyMorganz/stylua" "0.18.1"
-verify_github_tool lune-cli "filiptibell/lune" "0.6.7"
+verify_github_tool lune-cli "filiptibell/lune" "0.7.2"
 
 verify_gitlab_tool darklua "seaofvoices/darklua" "0.8.0"
 

--- a/tests/snapshots/install_all_tools_before_failing.snap
+++ b/tests/snapshots/install_all_tools_before_failing.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli.rs
+assertion_line: 100
 expression: content
 ---
 [INFO ] Downloading github.com/Roblox/NotARepository@^0.1.0
@@ -15,7 +16,11 @@ expression: content
         Request from `https://api.github.com/repos/Roblox//releases`
         
         Received body:
-        {"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}
+        {
+          "message": "Not Found",
+          "documentation_url": "https://docs.github.com/rest",
+          "status": "404"
+        }
 [INFO ] Downloading github.com/Roblox/VeryFakeRepository@^0.1.0
 [ERROR] The following error occurred while trying to download tool "not-a-real-tool":
         unexpected response body: invalid type: map, expected a sequence at line 1 column 0


### PR DESCRIPTION
Some folks have mentioned having issues with fine-grained tokens. Let's explicitly tell users to create `Tokens (classic)` Personal Access Tokens